### PR TITLE
Adjust Golang and official semver definitions

### DIFF
--- a/lib/fluent/plugin/calyptia_monitoring_calyptia_api_requester.rb
+++ b/lib/fluent/plugin/calyptia_monitoring_calyptia_api_requester.rb
@@ -37,12 +37,17 @@ module Fluent::Plugin
         ENV['HTTPS_PROXY'] || ENV['HTTP_PROXY'] || ENV['http_proxy'] || ENV['https_proxy']
       end
 
+      def create_go_semver(version)
+        version.gsub(/.(?<prever>(rc|alpha|beta|pre))/,
+                     '-\k<prever>')
+      end
+
       def agent_metadata(current_config)
         metadata = {
           "name" => Socket.gethostname,
           "type" => "fluentd",
           "rawConfig" => current_config,
-          "version" => Fluent::VERSION,
+          "version" => create_go_semver(Fluent::VERSION),
           "edition" => "community".freeze,
         }
         if system_config.workers.to_i > 1

--- a/test/plugin/test_calyptia_monitoring_calyptia_api_requester.rb
+++ b/test/plugin/test_calyptia_monitoring_calyptia_api_requester.rb
@@ -1,0 +1,29 @@
+require "helper"
+require "logger"
+require "fluent/plugin/calyptia_monitoring_calyptia_api_requester"
+
+class CalyptiaMonitoringMachineIdTest < Test::Unit::TestCase
+  API_KEY = 'YOUR_API_KEY'.freeze
+  API_ENDPOINT = "https://cloud-api.calyptia.com".freeze
+
+  setup do
+    @log = Logger.new($stdout)
+    worker_id = [1,2,3,4,5,6,7,8,9,10,11].sample
+    @api_requester = Fluent::Plugin::CalyptiaAPI::Requester.new(API_ENDPOINT,
+                                                                API_KEY,
+                                                                @log,
+                                                                worker_id)
+  end
+
+  data("rc" => ["1.14.0.rc", "1.14.0-rc"],
+       "rc2" => ["1.14.0.rc2", "1.14.0-rc2"],
+       "alpha" => ["1.14.0.alpha", "1.14.0-alpha"],
+       "beta" => ["1.14.0.beta", "1.14.0-beta"],
+       "pre" => ["1.14.0.pre", "1.14.0-pre"],
+      )
+  def test_create_go_semver(data)
+    version, expected = data
+    actual = @api_requester.create_go_semver(version)
+    assert_equal expected, actual
+  end
+end


### PR DESCRIPTION
RubyGems using one is weird for other languages' semver implementation.
We should manipulate to adjust official's semver definitions:
https://semver.org/#spec-item-9

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>