### PR TITLE
Migrate new metrics sending endpoint

### DIFF
--- a/lib/fluent/plugin/calyptia_monitoring_calyptia_api_requester.rb
+++ b/lib/fluent/plugin/calyptia_monitoring_calyptia_api_requester.rb
@@ -108,7 +108,7 @@ module Fluent::Plugin
       # POST /v1/agents/:agent_id/metrics
       # Authorization: X-Agent-Token
       def add_metrics(metrics, agent_token, agent_id)
-        url = URI("#{@endpoint}/v1/agents/#{agent_id}/metrics")
+        url = URI("#{@endpoint}/v1/agent_metrics")
 
         https = if proxy = proxies
                   proxy_uri = URI.parse(proxy)


### PR DESCRIPTION
We don't need to pas agent id on metrics endpoint.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>