### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,38 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  non-Windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest', 'macos-latest' ]
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+    name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Test
+        run: bundle exec rake
+
+  Windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.7', '3.0', '3.1', '3.2' ]
+    name: Ruby ${{ matrix.ruby }} on Windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - name: Install dependencies
+        run: ridk exec bundle install
+      - name: Test
+        run: bundle exec rake

--- a/fluent-plugin-calyptia-monitoring.gemspec
+++ b/fluent-plugin-calyptia-monitoring.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = test_files
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.2.15"
+  spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "test-unit", "~> 3.3"
   spec.add_runtime_dependency "fluentd", [">= 1.14.0", "< 2"]


### PR DESCRIPTION
The next [td-agent](https://github.com/fluent/fluent-package-builder) will embed Ruby 3.2.

I was checking each embedded plugin and noticed that this plugin has no CI.

How about adding CI?

I have confirmed that this works on my forked repository: https://github.com/daipom/fluent-plugin-calyptia-monitoring/actions/runs/4234120312
